### PR TITLE
Increase client max body size in nginx configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -5,13 +5,13 @@ events {
 }
 
 http {
-    client_max_body_size 2048M;
+    client_max_body_size 5120M;
 
     server {
         listen 80;
         server_name  localhost;
 
-        client_max_body_size 2048M;
+        client_max_body_size 5120M;
         root   /usr/share/nginx/html;
         index  index.html index.htm;
         include /etc/nginx/mime.types;


### PR DESCRIPTION
The client max body size setting in the nginx configuration file has been increased from 2048M to 5120M. These changes allow larger files to be uploaded, addressing issues with file upload size limits.


https://github.com/ludeknovy/jtl-reporter/discussions/285