### PR TITLE
Fix: Scenario trends chart point not clickable when page loaded anonymously

### DIFF
--- a/src/app/scenario/scenario-trends/scenario-trends.component.ts
+++ b/src/app/scenario/scenario-trends/scenario-trends.component.ts
@@ -16,6 +16,7 @@ import { normalizeOverviewData } from "../../utils/normalizeOverviewData";
 })
 export class ScenarioTrendsComponent implements OnInit {
   @Input() params;
+  @Input() isAnonymous: boolean;
   Highcharts: typeof Highcharts = Highcharts;
   updateAggregatedScenarioTrendsChartFlag = false;
   updateLabelScenarioTrendsChartFlag = false;
@@ -159,7 +160,7 @@ export class ScenarioTrendsComponent implements OnInit {
   }
 
   onPointSelect(event) {
-    if (event && event.point && event.point) {
+    if (event && event.point && !this.isAnonymous) {
       // Label series have item id amended to open correct detail, it's needed for a case when a labels do not match, eg:
       // label2 start at point 0, but label2 starts at point 1, it leads to off by N issues.
       // It's not needed for aggregated trend chart, as that is column chart and only one point can be clicked.

--- a/src/app/scenario/scenario.component.html
+++ b/src/app/scenario/scenario.component.html
@@ -31,7 +31,7 @@
     <div class="items-overview content-container">
       <div class="container-fluid">
 
-        <app-scenario-trends [params]="params"></app-scenario-trends>
+        <app-scenario-trends [params]="params" [isAnonymous]="isAnonymous"></app-scenario-trends>
 
         <div class="row rr" *ngIf="!isAnonymous">
           <div class="col" *ngIf="items$ | async; let items">


### PR DESCRIPTION
Extended ScenarioTrendsComponent to accept the isAnonymous input parameter. Adjusted the onPointSelect method to respect this isAnonymous flag, ensuring point selection handling changes based on anonymity.

https://github.com/ludeknovy/jtl-reporter/issues/290