### PR TITLE
Remove duplicate header column from item detail template

### DIFF
--- a/src/app/item-detail/item-detail.component.html
+++ b/src/app/item-detail/item-detail.component.html
@@ -508,9 +508,6 @@
                               <mfDefaultSorter by="errorRate">error rate [%]</mfDefaultSorter>
                             </th>
                             <th scope="col" class="hd jtl-head-color">
-                              <mfDefaultSorter by="errorRate">error rate [%]</mfDefaultSorter>
-                            </th>
-                            <th scope="col" class="hd jtl-head-color">
                             </th>
                             <th scope="col" class="hd jtl-head-color">
                             </th>


### PR DESCRIPTION
A redundant table header for "error rate [%]" was removed from the item-detail.component.html file. This change improves the clarity and structure of the table without altering its functionality.