### PR TITLE
Add runtime support for custom base href and API prefix via entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,10 @@ FROM nginx:alpine
 COPY nginx.conf /etc/nginx/nginx.conf
 
 COPY --from=builder /src/fe/dist/jtl-reporter/ /usr/share/nginx/html
+
+# Runtime patching support for baseHref and API endpoints override
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Override the default NGINX startup
+CMD ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
+## Support for deployment of this image behind a reverse proxy
+
+Supports dynamic runtime paths using BASE_HREF and API_PREFIX environment variables to override the default `/` root and `/api` path respectively.
+
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+BASE_HREF="${BASE_HREF:-/}"
+API_PREFIX="${API_PREFIX:-/api}"
+
+HTML_PATH="/usr/share/nginx/html"
+INDEX_FILE="$HTML_PATH/index.html"
+
+echo "[INFO] Patching <base href> to '$BASE_HREF'"
+sed -i "s|<base href=\"[^\"]*\">|<base href=\"$BASE_HREF\">|g" "$INDEX_FILE"
+
+echo "[INFO] Patching JS files to use '$API_PREFIX'"
+sed -i "s|/api\"|$API_PREFIX\"|g" "$HTML_PATH"/*.js
+
+echo "[INFO] Starting nginx..."
+nginx -g 'daemon off;'


### PR DESCRIPTION
This PR adds an `entrypoint.sh` script to allow runtime configuration of:

Angular `<base href>` for subpath deployments (e.g. `/my-app/`)

JS bundle API paths (e.g. `/api/info` → `/my-app/api/info`)

This enables dynamic deployments behind reverse proxies without rebuilding the image.
Environment variables:

*`BASE_HREF` (default: `/`)

*`API_PREFIX` (default: `/api`)

No changes are made to the build logic or application source.

Fixes ludeknovy/jtl-reporter#323