### PR TITLE
feat: add multi-select batch delete for scenario items

### DIFF
--- a/src/app/items-api.service.ts
+++ b/src/app/items-api.service.ts
@@ -60,6 +60,12 @@ export class ItemsApiService {
     return this.http.delete(`projects/${projectName}/scenarios/${scenarioName}/items/${itemId}`, { observe: "response" });
   }
 
+  deleteItems(itemIds: string[], scenarioName: string, projectName: string): Observable<HttpResponse<any>> {
+    return this.http.request<any>("DELETE",
+      `projects/${projectName}/scenarios/${scenarioName}/items`,
+      { body: { itemIds }, observe: "response" });
+  }
+
   fetchItems(projectName: string, scenarioName, params): Observable<Items> {
     return this.http.get<Items>(
       `projects/${projectName}/scenarios/${scenarioName}/items`, { params });

--- a/src/app/scenario/scenario.component.html
+++ b/src/app/scenario/scenario.component.html
@@ -44,11 +44,27 @@
                     class="text-secondary in-progress">{{processingItems.inprogress?.length}} <i
                       class="far fa-clock"></i></span></span>
               </h6>
+              <div class="batch-delete-bar" *ngIf="selectedCount > 0 && !isAnonymous">
+                <span class="me-2">{{ selectedCount }} item(s) selected</span>
+                <app-batch-delete-item
+                  [selectedIds]="selectedIds"
+                  [projectName]="params.projectName"
+                  [scenarioName]="params.scenarioName"
+                  (deleted)="clearSelection()">
+                </app-batch-delete-item>
+                <button class="btn btn-sm btn-link" (click)="clearSelection()">Cancel</button>
+              </div>
               <div class="card-body card-table">
                 <div class="table-responsive">
-                  <table class="table items jtl-table" [mfData]="items.data" #mf="mfDataTable">
+                    <table class="table items jtl-table" [mfData]="items.data" #mf="mfDataTable">
                     <thead>
                       <tr>
+                        <th scope="col" class="jtl-head jtl-head-color" style="width: 40px;">
+                          <input type="checkbox"
+                            (change)="toggleSelectAll(mf.data)"
+                            [checked]="selectedItems.size === mf.data?.length && mf.data?.length > 0"
+                            [disabled]="isAnonymous">
+                        </th>
                         <th scope="col" class="jtl-head jtl-head-color">
                           <mfDefaultSorter by="name">name</mfDefaultSorter>
                         </th>
@@ -76,11 +92,17 @@
                     </thead>
                     <tbody *ngIf="!isLoading && items.data.length === 0">
                       <tr>
-                        <td colspan="8" class="text-muted text-center">Nothing here yet! Please upload some test reports.</td>
+                        <td colspan="9" class="text-muted text-center">Nothing here yet! Please upload some test reports.</td>
                       </tr>
                     </tbody>
                     <tbody *ngIf="items.data.length > 0">
                       <tr *ngFor="let _ of mf.data">
+                        <td class="text-center" (click)="$event.stopPropagation()">
+                          <input type="checkbox"
+                            [checked]="selectedItems.has(_.id)"
+                            (change)="toggleSelectItem(_.id)"
+                            [disabled]="isAnonymous">
+                        </td>
                         <td (click)="open(_.id)"> {{_.name || 'test run '}}</td>
                         <td (click)="open(_.id)">
                           {{_.overview.maxVu}}

--- a/src/app/scenario/scenario.component.scss
+++ b/src/app/scenario/scenario.component.scss
@@ -161,3 +161,12 @@ tbody tr:hover {
   border:none;
   padding-top: 10px;
 }
+
+.batch-delete-bar {
+  display: flex;
+  align-items: center;
+  padding: 8px 20px;
+  background-color: #fff3cd;
+  border-bottom: 1px solid #ffc107;
+  font-size: 14px;
+}

--- a/src/app/scenario/scenario.component.ts
+++ b/src/app/scenario/scenario.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy } from "@angular/core";
 import { ActivatedRoute, Router } from "@angular/router";
 import { of, Observable, Subscription } from "rxjs";
 import { switchMap, catchError, withLatestFrom } from "rxjs/operators";
-import { Items } from "../items.service.model";
+import { Items, ItemsListing } from "../items.service.model";
 import { ItemsService } from "../items.service";
 import { SharedMainBarService } from "../shared-main-bar.service";
 import { ScenarioService } from "../scenario.service";
@@ -33,6 +33,36 @@ export class ScenarioComponent implements OnInit, OnDestroy {
   validationEnabled = false
   minTestDuration = null
   isLoading = true;
+  selectedItems: Set<string> = new Set();
+
+  get selectedCount(): number {
+    return this.selectedItems.size;
+  }
+
+  get selectedIds(): string[] {
+    return [...this.selectedItems];
+  }
+
+  toggleSelectItem(itemId: string): void {
+    if (this.selectedItems.has(itemId)) {
+      this.selectedItems.delete(itemId);
+    } else {
+      this.selectedItems.add(itemId);
+    }
+  }
+
+  toggleSelectAll(visibleItems: ItemsListing[]): void {
+    if (!visibleItems || visibleItems.length === 0) return;
+    if (this.selectedItems.size === visibleItems.length) {
+      this.selectedItems.clear();
+    } else {
+      this.selectedItems = new Set(visibleItems.map(i => i.id));
+    }
+  }
+
+  clearSelection(): void {
+    this.selectedItems.clear();
+  }
 
   constructor(
     private route: ActivatedRoute,

--- a/src/app/scenario/scenario.module.ts
+++ b/src/app/scenario/scenario.module.ts
@@ -13,6 +13,7 @@ import { SharedModule } from "../shared/shared.module";
 import { HighchartsChartModule } from "highcharts-angular";
 import { ItemControlsComponent } from "./item-controls/item-controls.component";
 import { SharedItemModule } from "../shared/shared-item/shared-item.module";
+import { BatchDeleteItemModule } from "../shared/shared-item/batch-delete-item/batch-delete-item.module";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { DataTableModule } from "@pascalhonegger/ng-datatable";
 import {
@@ -44,7 +45,7 @@ const routes: Routes = [
   ],
   imports: [
     CommonModule, RouterModule.forRoot(routes), NgxSpinnerModule, NgbModule, SharedModule, HighchartsChartModule,
-    SharedItemModule, ReactiveFormsModule, DataTableModule, RoleModule, AddNewItemModule, FormsModule,
+    SharedItemModule, ReactiveFormsModule, DataTableModule, RoleModule, AddNewItemModule, FormsModule, BatchDeleteItemModule,
 
   ],
   exports: [ScenarioComponent, ScenarioTrendsComponent,

--- a/src/app/shared/shared-item/batch-delete-item/batch-delete-item.component.html
+++ b/src/app/shared/shared-item/batch-delete-item/batch-delete-item.component.html
@@ -1,0 +1,29 @@
+<ng-template #content let-modal>
+  <div class="modal-header">
+    <h5 class="modal-title" id="modal-basic-title">Delete {{ selectedIds.length }} test(s)</h5>
+    <button type="button" style="outline: none;" class="btn-close" aria-label="Close"
+      (click)="modal.dismiss('Cross click')"></button>
+  </div>
+  <form [formGroup]="myform" (ngSubmit)="onSubmit()">
+    <div class="modal-body">
+      <p>Are you sure you want to delete <strong>{{ selectedIds.length }}</strong> test run(s)?</p>
+      <div class="form-group mb-3">
+        <label for="deleteCheck" class="form-label">Please enter 5 random characters:</label>
+        <input type="text" id="deleteCheck" class="form-control" formControlName="deleteCheck"
+          aria-label="Delete confirmation input">
+        <div class="form-control-feedback" *ngIf="deleteCheck.errors && (deleteCheck.dirty || deleteCheck.touched)">
+          <p class="form-validation-error" *ngIf="deleteCheck.errors.minlength">
+            Please enter at least 5 characters...
+          </p>
+        </div>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="submit" class="btn btn-danger" [disabled]="!myform.valid">Delete</button>
+    </div>
+  </form>
+</ng-template>
+
+<button class="btn btn-sm btn-danger me-2" (click)="open(content)">
+  Delete selected ({{ selectedIds.length }})
+</button>

--- a/src/app/shared/shared-item/batch-delete-item/batch-delete-item.component.spec.ts
+++ b/src/app/shared/shared-item/batch-delete-item/batch-delete-item.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BatchDeleteItemComponent } from "./batch-delete-item.component";
+import { ReactiveFormsModule } from "@angular/forms";
+import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
+import { ItemsApiService } from "src/app/items-api.service";
+import { ItemsService } from "src/app/items.service";
+import { ScenarioService } from "src/app/scenario.service";
+import { of } from "rxjs";
+
+describe("BatchDeleteItemComponent", () => {
+  let component: BatchDeleteItemComponent;
+  let fixture: ComponentFixture<BatchDeleteItemComponent>;
+
+  const mockItemsApiService = jasmine.createSpyObj("ItemsApiService", ["deleteItems", "setData"]);
+  const mockItemsService = jasmine.createSpyObj("ItemsService", ["fetchItems"]);
+  const mockScenarioService = jasmine.createSpyObj("ScenarioService", ["fetchScenarioTrends"]);
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [BatchDeleteItemComponent],
+      imports: [ReactiveFormsModule, NgbModule],
+      providers: [
+        { provide: ItemsApiService, useValue: mockItemsApiService },
+        { provide: ItemsService, useValue: mockItemsService },
+        { provide: ScenarioService, useValue: mockScenarioService },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(BatchDeleteItemComponent);
+    component = fixture.componentInstance;
+    component.selectedIds = ["id-1", "id-2"];
+    component.projectName = "test-project";
+    component.scenarioName = "test-scenario";
+    fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
+  });
+
+  it("should call deleteItems on submit", () => {
+    mockItemsApiService.deleteItems.and.returnValue(of({ status: 204 }));
+    component.myform.setValue({ deleteCheck: "abcde" });
+    component.onSubmit();
+    expect(mockItemsApiService.deleteItems).toHaveBeenCalledWith(
+      ["id-1", "id-2"], "test-scenario", "test-project"
+    );
+    expect(mockItemsService.fetchItems).toHaveBeenCalled();
+    expect(mockScenarioService.fetchScenarioTrends).toHaveBeenCalled();
+  });
+});

--- a/src/app/shared/shared-item/batch-delete-item/batch-delete-item.component.ts
+++ b/src/app/shared/shared-item/batch-delete-item/batch-delete-item.component.ts
@@ -1,0 +1,61 @@
+import { Component, Input, Output, EventEmitter } from "@angular/core";
+import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
+import { FormGroup, FormControl, Validators } from "@angular/forms";
+import { ItemsApiService } from "src/app/items-api.service";
+import { ItemsService } from "src/app/items.service";
+import { ScenarioService } from "src/app/scenario.service";
+import { catchError } from "rxjs/operators";
+import { of } from "rxjs";
+
+@Component({
+  selector: "app-batch-delete-item",
+  templateUrl: "./batch-delete-item.component.html",
+  styleUrls: ["./batch-delete-item.component.css"]
+})
+export class BatchDeleteItemComponent {
+  myform: FormGroup;
+  deleteCheck: FormControl;
+
+  @Input() selectedIds: string[] = [];
+  @Input() projectName: string;
+  @Input() scenarioName: string;
+  @Output() deleted = new EventEmitter<void>();
+
+  constructor(
+    private modalService: NgbModal,
+    private itemsService: ItemsService,
+    private itemApiService: ItemsApiService,
+    private scenarioService: ScenarioService,
+  ) {
+    this.deleteCheck = new FormControl("", [
+      Validators.required,
+      Validators.minLength(5),
+    ]);
+    this.myform = new FormGroup({ deleteCheck: this.deleteCheck });
+  }
+
+  open(content) {
+    if (this.selectedIds.length === 0) return;
+    this.myform.reset();
+    this.modalService.open(content, { ariaLabelledBy: "modal-basic-title" });
+  }
+
+  onSubmit() {
+    if (!this.myform.valid) return;
+
+    this.itemApiService.deleteItems(this.selectedIds, this.scenarioName, this.projectName)
+      .pipe(catchError(r => of(r)))
+      .subscribe(res => {
+        if (res.status >= 200 && res.status < 300) {
+          this.itemsService.fetchItems(this.projectName, this.scenarioName);
+          this.scenarioService.fetchScenarioTrends(this.projectName, this.scenarioName);
+          const count = this.selectedIds.length;
+          const msg = count > 1 ? `${count} tests have been deleted` : "Test has been deleted";
+          this.itemApiService.setData({ success: true, message: msg });
+          this.deleted.emit();
+        }
+        this.myform.reset();
+        this.modalService.dismissAll();
+      });
+  }
+}

--- a/src/app/shared/shared-item/batch-delete-item/batch-delete-item.module.ts
+++ b/src/app/shared/shared-item/batch-delete-item/batch-delete-item.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from "@angular/core";
+import { CommonModule } from "@angular/common";
+import { ReactiveFormsModule } from "@angular/forms";
+import { NgbModule } from "@ng-bootstrap/ng-bootstrap";
+import { BatchDeleteItemComponent } from "./batch-delete-item.component";
+
+@NgModule({
+  declarations: [BatchDeleteItemComponent],
+  imports: [CommonModule, ReactiveFormsModule, NgbModule],
+  exports: [BatchDeleteItemComponent],
+})
+export class BatchDeleteItemModule {}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  baseUrl: "http://localhost:5050/api"
+  baseUrl: "http://localhost:5000/api"
 };
 
 /*


### PR DESCRIPTION
## Summary
Adds checkbox-based multi-selection to the scenario items table, allowing users to select multiple test runs and delete them all at once.
## Changes
### New files
- `batch-delete-item.component.ts` / `.html` / `.css` — Component with confirmation modal for batch delete
- `batch-delete-item.module.ts` — Module declaration
- `batch-delete-item.component.spec.ts` — Unit tests
### Modified files
- `items-api.service.ts` — Added `deleteItems()` method using `DELETE` with body
- `scenario.component.ts` — Added selection state (`Set<string>`), toggle methods, `clearSelection()`
- `scenario.component.html` — Added checkbox column, select-all header, batch delete bar
- `scenario.component.scss` — Styles for `.batch-delete-bar`
- `scenario.module.ts` — Imported `BatchDeleteItemModule`
### UX Flow
1. User checks items → batch bar appears: "N item(s) selected [Delete selected (N)] Cancel"
2. Click "Delete selected" → modal with type-to-confirm (5 chars)
3. On confirm → `DELETE /api/projects/:p/scenarios/:s/items` with `{ itemIds }` body
4. On success → list refreshes, selection clears, trends update
### Related
- Backend PR: https://github.com/ludeknovy/jtl-reporter-be/pull/383
## Testing
- `batch-delete-item.component.spec.ts` — unit tests for submit flow
- Manual: select items, batch delete, verify list refresh and selection clear